### PR TITLE
report nav bar

### DIFF
--- a/static/report-style.css
+++ b/static/report-style.css
@@ -116,6 +116,10 @@ button:hover {
         display: none; /* Hide the button in the PDF */
     }
 
+    a {
+        display: none; /* Hide the links in the PDF */
+    }
+
     #report-container {
         margin: 0;
         padding: 0;

--- a/templates/report.html
+++ b/templates/report.html
@@ -7,7 +7,7 @@
   <link rel="stylesheet" href="../static/report-style.css">
   <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
   <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Symbols+Outlined">
-  <script src="../static/report-script.js" defer></script>
+  <script src="../static/script.js" defer></script>
 </head>
 
 <header>


### PR DESCRIPTION
Removed the navbar from visibility when converting the report to pdf 
also fixed the js link 

![image](https://github.com/user-attachments/assets/ecfe0e89-7b6d-4713-af27-5ea6cd7e635a)
